### PR TITLE
change keycloak auth grant type to client credentials

### DIFF
--- a/keycloak-data-loader/README.md
+++ b/keycloak-data-loader/README.md
@@ -12,15 +12,14 @@ Currently this program will:
  
 The program does not remove any user configuration and the same file can be imported multiple times to produce the same end result.
 # Configuration
-* Properties are used as follows. KeePass file DevPasswords entry Keycloak -> IAM keycloak-data-loader user - * contains environment specific info for _url_, _username_ and _password_ properties. _realm_, _application_ and _username-type_ are set based on the client requesting the upload:
+* Properties are used as follows. KeePass file DevPasswords entry Keycloak -> IAM keycloak-data-loader user - * contains environment specific info for _url_, _client-id_ and _client-secret_ properties. _realm_, _application_ and _username-type_ are set based on the client requesting the upload:
 	* url = The URL of the keycloak instance e.g. https://common-logon-dev.hlth.gov.bc.ca/auth
 	* realm = The realm the upload will be run against e.g. moh_applications
-	* username = The username of the user created for running the uploads
-	* password = The password of the user created for running the uploads
-	* client-id = The admin client for this realm e.g. admin-cli
+	* client-id = Client ID of the service account that executes the script (BULK-USER-UPLOAD)
 	* application = The application/client the info is being uploaded for e.g. MSPDirect-Service
 	* username-type = This value will be used to indicate if a prefix or suffix is to be added to the supplied usernames. Valid values are specified in the UsernameTypeEnum, which defines the value to be added to the username and whether it is prefix or suffix e.g. IDIR defines a suffix of @idir so with supplied username 'test1' would result in username of 'test1@idir' being processed. If no change to the username is required then specify NONE and the username will processed as supplied.
 	* data-file-location = The location of the file containing the keycloak user data to be uploaded. This file will be created based on the data in the clients request.
+    * Additionally, developer needs to set an environment variable BULK-USER-UPLOAD-CLIENT-SECRET-*ENV* where client secret is stored.
 # Run
 * Create a file in format described above.
 * Using the configuration.properties as a template set the properties for the environment against which the script will be run in a suitably named file e.g. configuration-dev.properties.

--- a/keycloak-data-loader/src/main/java/ca/bc/gov/hlth/iam/dataloader/service/EnvironmentEnum.java
+++ b/keycloak-data-loader/src/main/java/ca/bc/gov/hlth/iam/dataloader/service/EnvironmentEnum.java
@@ -2,25 +2,25 @@ package ca.bc.gov.hlth.iam.dataloader.service;
 
 public enum EnvironmentEnum {
 
-	DEV("dev", "DATA_LOADER_USER_PASSWORD_DEV"),
-	TEST("test", "DATA_LOADER_USER_PASSWORD_TEST"),
-	PROD("prod", "DATA_LOADER_USER_PASSWORD_PROD");
+	DEV("dev", "BULK-USER-UPLOAD-CLIENT-SECRET-DEV"),
+	TEST("test", "BULK-USER-UPLOAD-CLIENT-SECRET-TEST"),
+	PROD("prod", "BULK-USER-UPLOAD-CLIENT-SECRET-PROD");
 
 	private String value;
 	
-	private String passwordKey;
+	private String clientSecret;
 
-	private EnvironmentEnum(String value, String passwordKey) {
+	private EnvironmentEnum(String value, String clientSecret) {
 		this.value = value;
-		this.passwordKey = passwordKey;
+		this.clientSecret = clientSecret;
 	}
 
 	public String getValue() {
 		return value;
 	}
 
-	public String getPasswordKey() {
-		return passwordKey;
+	public String getClientSecret() {
+		return clientSecret;
 	}
 
 }

--- a/keycloak-data-loader/src/main/java/ca/bc/gov/hlth/iam/dataloader/service/KeycloakService.java
+++ b/keycloak-data-loader/src/main/java/ca/bc/gov/hlth/iam/dataloader/service/KeycloakService.java
@@ -38,8 +38,6 @@ public class KeycloakService {
 
 	private static final String CONFIG_PROPERTY_CLIENT_ID = "client-id";
 
-	private static final String CONFIG_PROPERTY_USERNAME = "username";
-	
 	private static final String CONFIG_PROPERTY_USERNAME_TYPE = "username-type";
 
 	private static final String ZERO_WIDTH_NOBREAK_SPACE = "\ufeff"; //Zero Width No-Break Space (BOM, ZWNBSP) https://www.compart.com/en/unicode/U+FEFF
@@ -73,10 +71,9 @@ public class KeycloakService {
 		Keycloak keycloak = KeycloakBuilder.builder()
 				.serverUrl(configProperties.getProperty(CONFIG_PROPERTY_URL))
 				.realm(realm)
-				.grantType(OAuth2Constants.PASSWORD)
-				.clientId(configProperties.getProperty(CONFIG_PROPERTY_CLIENT_ID)) //
-				.username(configProperties.getProperty(CONFIG_PROPERTY_USERNAME))
-				.password(getUserPassword(environment))
+				.grantType(OAuth2Constants.CLIENT_CREDENTIALS)
+				.clientId(configProperties.getProperty(CONFIG_PROPERTY_CLIENT_ID))
+				.clientSecret(getClientSecret(environment))
 				.build();
 				
 		realmResource = keycloak.realm(realm);
@@ -278,8 +275,8 @@ public class KeycloakService {
 		return isComplete;
 	}
 
-    private static String getUserPassword(EnvironmentEnum environment) {        
-        return System.getenv(environment.getPasswordKey());
+    private static String getClientSecret(EnvironmentEnum environment) {
+        return System.getenv(environment.getClientSecret());
     }
 
 	private void printSummary() {

--- a/keycloak-data-loader/src/main/resources/configuration.properties
+++ b/keycloak-data-loader/src/main/resources/configuration.properties
@@ -1,7 +1,6 @@
 # Keycloak connection instance details
 url=
 realm=
-username=
 client-id=
 
 # The application/client the info is being uploaded for


### PR DESCRIPTION
Changing Keycloak authentication from username/password to client credentials grant. This will allow for management of service accounts in terraform and reduces usage of admin-cli client.